### PR TITLE
[REFACTOR]: ️ Workspace 도메인 양방향 연관관계 제거

### DIFF
--- a/src/main/java/project/common/config/SecurityConfig.java
+++ b/src/main/java/project/common/config/SecurityConfig.java
@@ -92,7 +92,7 @@ public class SecurityConfig {
         http.cors().configurationSource(corsConfigurationSource());
 
         http.authorizeHttpRequests(authorize -> authorize
-                .requestMatchers("/v1/login", "/v1/refresh", "/v1/login/oauth2", "/v1/login/dumy")
+                .requestMatchers("/v1/login", "/v1/refresh", "/v1/login/oauth2")
                 .permitAll()
                 .requestMatchers(
                         "/v1/sign-up", "/v1/users/email", "/v1/users/email/code", "/v1/users/nickname", "/v1/image")

--- a/src/main/java/project/common/config/SecurityConfig.java
+++ b/src/main/java/project/common/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import static org.springframework.security.config.Customizer.withDefaults;
 import static project.common.constant.EnvironmentConstant.*;
 import static project.common.constant.UrlConstant.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
@@ -12,6 +13,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -19,6 +21,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.oauth2.client.web.OAuth2LoginAuthenticationFilter;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.web.cors.*;
 import project.common.property.BasicAuthProperty;
 import project.common.security.jwt.*;
@@ -29,12 +32,10 @@ import project.common.util.EnvironmentUtil;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final CustomAccessDeniedHandler customAccessDeniedHandler;
-    private final JwtAuthorizationFilter jwtAuthorizationFilter;
-    private final CustomExceptionHandlerFilter customExceptionHandlerFilter;
-    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final EnvironmentUtil environmentUtil;
     private final BasicAuthProperty basicAuthProperty;
+    private final ObjectMapper objectMapper;
+    private final JwtProvider jwtProvider;
 
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
@@ -42,35 +43,21 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    @Order(1)
+    @Profile({"local"})
+    public SecurityFilterChain h2ConsoleFilterChain(HttpSecurity http) throws Exception {
         defaultFilterChain(http);
 
-        http.cors().configurationSource(corsConfigurationSource());
-
-        http.authorizeHttpRequests(authorize -> authorize
-                .requestMatchers("/v1/login", "/v1/refresh", "/v1/login/oauth2", "/v1/login/dumy")
-                .permitAll()
-                .requestMatchers(
-                        "/v1/sign-up", "/v1/users/email", "/v1/users/email/code", "/v1/users/nickname", "/v1/image")
-                .permitAll()
-                .requestMatchers("/admin/**", "/css/**", "*.ico")
-                .permitAll()
-                .requestMatchers("/v1/**")
-                .hasAnyRole("USER", "ADMIN")
-                .anyRequest()
-                .authenticated());
-
-        http.exceptionHandling().authenticationEntryPoint(customAuthenticationEntryPoint);
-        http.exceptionHandling().accessDeniedHandler(customAccessDeniedHandler);
-
-        http.addFilterBefore(customExceptionHandlerFilter, OAuth2LoginAuthenticationFilter.class)
-                .addFilterAfter(jwtAuthorizationFilter, OAuth2LoginAuthenticationFilter.class);
+        http.securityMatcher(new AntPathRequestMatcher("/h2-console/**"))
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .csrf(csrf -> csrf.ignoringRequestMatchers(new AntPathRequestMatcher("/h2-console/**")))
+                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin));
 
         return http.build();
     }
 
     @Bean
-    @Order(1)
+    @Order(2)
     @Profile({"local", "dev"})
     public SecurityFilterChain swaggerFilterChain(HttpSecurity http) throws Exception {
         defaultFilterChain(http);
@@ -86,15 +73,6 @@ public class SecurityConfig {
         return http.build();
     }
 
-    private void defaultFilterChain(HttpSecurity http) throws Exception {
-        http.httpBasic(AbstractHttpConfigurer::disable)
-                .formLogin(AbstractHttpConfigurer::disable)
-                .logout(AbstractHttpConfigurer::disable)
-                .csrf(AbstractHttpConfigurer::disable)
-                .cors(withDefaults())
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
-    }
-
     @Bean
     @Profile({"local", "dev"})
     public InMemoryUserDetailsManager inMemoryUserDetailsManager() {
@@ -104,6 +82,44 @@ public class SecurityConfig {
                 .build();
 
         return new InMemoryUserDetailsManager(user);
+    }
+
+    @Order(3)
+    @Bean
+    public SecurityFilterChain apiFilterChain(HttpSecurity http) throws Exception {
+        defaultFilterChain(http);
+
+        http.cors().configurationSource(corsConfigurationSource());
+
+        http.authorizeHttpRequests(authorize -> authorize
+                .requestMatchers("/v1/login", "/v1/refresh", "/v1/login/oauth2", "/v1/login/dumy")
+                .permitAll()
+                .requestMatchers(
+                        "/v1/sign-up", "/v1/users/email", "/v1/users/email/code", "/v1/users/nickname", "/v1/image")
+                .permitAll()
+                .requestMatchers("/css/**", "*.ico")
+                .permitAll()
+                .requestMatchers("/v1/**")
+                .hasAnyRole("USER", "ADMIN")
+                .anyRequest()
+                .authenticated());
+
+        http.exceptionHandling().authenticationEntryPoint(new CustomAuthenticationEntryPoint(objectMapper));
+        http.exceptionHandling().accessDeniedHandler(new CustomAccessDeniedHandler(objectMapper));
+
+        http.addFilterBefore(new CustomExceptionHandlerFilter(objectMapper), OAuth2LoginAuthenticationFilter.class)
+                .addFilterAfter(new JwtAuthorizationFilter(jwtProvider), OAuth2LoginAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    private void defaultFilterChain(HttpSecurity http) throws Exception {
+        http.httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .logout(AbstractHttpConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(withDefaults())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
     }
 
     @Bean // 여기도 환경별 설정 해줘야함

--- a/src/main/java/project/common/security/jwt/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/project/common/security/jwt/CustomAuthenticationEntryPoint.java
@@ -10,14 +10,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
-import org.springframework.stereotype.Component;
 import project.common.exception.ErrorResponse;
 
 /**
  * 인증되지 않은 사용자가 보호된 리소스에 액세스하려고 할 때 발생하는 예외를 처리하는 클래스 (401 Unauthorized)
  */
 @Slf4j
-@Component
 @RequiredArgsConstructor
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 

--- a/src/main/java/project/common/security/jwt/CustomExceptionHandlerFilter.java
+++ b/src/main/java/project/common/security/jwt/CustomExceptionHandlerFilter.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import project.common.exception.ErrorCode;
 import project.common.exception.ErrorResponse;
@@ -19,7 +18,6 @@ import project.common.exception.PlantException;
  * 토큰 검증 중 토큰 올바르지 않을 때 발생하는 에러를 처리하는 필터 (401 Unauthorized)
  */
 @Slf4j
-@Component
 @RequiredArgsConstructor
 public class CustomExceptionHandlerFilter extends OncePerRequestFilter {
 

--- a/src/main/java/project/common/security/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/project/common/security/jwt/JwtAuthorizationFilter.java
@@ -9,12 +9,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 @Slf4j
 @RequiredArgsConstructor
-@Component
 public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
     private final JwtProvider jwtProvider;

--- a/src/main/java/project/common/security/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/project/common/security/jwt/JwtAuthorizationFilter.java
@@ -18,14 +18,6 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
     private final JwtProvider jwtProvider;
 
     @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
-        String path = request.getServletPath();
-        return path.startsWith("/swagger-ui")
-                || path.startsWith("/v3/api-docs")
-                || path.startsWith("/swagger-resources");
-    }
-
-    @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws IOException, ServletException {
 

--- a/src/main/java/project/domain/auth/api/LoginController.java
+++ b/src/main/java/project/domain/auth/api/LoginController.java
@@ -51,11 +51,4 @@ public class LoginController {
         var response = jwtProvider.createAccessTokenByRefreshToken(refreshToken);
         return ResponseEntity.ok(response);
     }
-
-    @Operation(summary = "더미 데이터 로그인", description = "더미 데이터 DB에 로그인합니다. 토큰을 응답 본문에 반환합니다.")
-    @PostMapping("/v1/login/dumy")
-    public ResponseEntity<TokenPairResponse> dumyLogin(@Valid @RequestBody EmailLoginRequest request) {
-        var response = loginService.loginInDumy(request.email(), request.password());
-        return ResponseEntity.ok(response);
-    }
 }

--- a/src/main/java/project/domain/workspace/api/WorkspaceController.java
+++ b/src/main/java/project/domain/workspace/api/WorkspaceController.java
@@ -6,11 +6,10 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import project.common.interceptor.auth.PermitUserRole;
 import project.common.util.DateFormatUtil;
-import project.domain.user.domain.UserRole;
 import project.domain.workspace.dto.request.WorkspaceCreateRequest;
 import project.domain.workspace.dto.request.WorkspaceUpdateRequest;
 import project.domain.workspace.dto.response.*;
@@ -27,7 +26,7 @@ public class WorkspaceController {
     @PostMapping("/v1/workspaces")
     public ResponseEntity<Long> createWorkspace(@RequestBody @Valid WorkspaceCreateRequest request) {
         var response = workspaceService.makeWorkspace(request);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @Operation(summary = "워크스페이스 수정", description = "워크스페이스 정보를 수정합니다. 워크스페이스 관리자 권한이 필요합니다.")
@@ -47,7 +46,6 @@ public class WorkspaceController {
 
     // TODO: 패키지 이동 검토
     @Operation(summary = "워크스페이스 별 스케줄 달력 조회", description = "워크스페이스 별 입력한 달의 스케줄 달력을 조회합니다.")
-    @PermitUserRole(value = {UserRole.ADMIN, UserRole.USER})
     @GetMapping("/v1/workspaces/{workspaceId}/calendar")
     public ResponseEntity<CalendarResponse> readCalendar(
             @PathVariable Long workspaceId, @Parameter(required = true, description = "yyyyMM") String date) {
@@ -58,7 +56,6 @@ public class WorkspaceController {
     }
 
     @Operation(summary = "워크스페이스 별 일일 스케줄 조회", description = "워크스페이스 별 입력한 날짜의 일일 스케줄을 조회합니다.")
-    @PermitUserRole(value = {UserRole.ADMIN, UserRole.USER})
     @GetMapping("/v1/workspaces/{workspaceId}/schedules")
     public ResponseEntity<CalendarResponse> readDailySchedule(
             @PathVariable Long workspaceId, @Parameter(required = true, description = "yyyyMMdd") String date) {

--- a/src/main/java/project/domain/workspace/dao/WorkspaceRepository.java
+++ b/src/main/java/project/domain/workspace/dao/WorkspaceRepository.java
@@ -4,17 +4,11 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import project.domain.workspace.domain.Workspace;
 
 public interface WorkspaceRepository extends JpaRepository<Workspace, Long> {
 
-    public Page<Workspace> findAll(Pageable pageable);
+    Page<Workspace> findAll(Pageable pageable);
 
-    public Optional<Workspace> findByName(String name);
-
-    public boolean existsByName(String name);
-
-    @Query(value = "select w from Workspace w join fetch w.profile where w.id = :id")
-    public Optional<Workspace> findById(Long id);
+    Optional<Workspace> findById(Long id);
 }

--- a/src/main/java/project/domain/workspace/service/WorkspaceService.java
+++ b/src/main/java/project/domain/workspace/service/WorkspaceService.java
@@ -118,7 +118,7 @@ public class WorkspaceService {
         Long loginUserId = userUtil.getLoginUserId();
         boolean isAdmin = workspaceUserUtil.isAdminUser(workspaceId, loginUserId);
 
-        if (isAdmin) {
+        if (!isAdmin) {
             throw new PlantException(ErrorCode.WORKSPACE_USER_AUTHORITY_INVALID);
         }
     }

--- a/src/main/java/project/domain/workspace/service/WorkspaceService.java
+++ b/src/main/java/project/domain/workspace/service/WorkspaceService.java
@@ -43,6 +43,7 @@ public class WorkspaceService {
         Workspace workspace = Workspace.create(request.name());
         workspaceRepository.save(workspace);
 
+        // TODO: 도메인 이벤트로 분리 고려
         User creator = userUtil.getLoginUser();
         WorkspaceUser workspaceUser = WorkspaceUser.createAdmin(workspace, creator);
         workspaceUserRepository.save(workspaceUser);
@@ -77,8 +78,6 @@ public class WorkspaceService {
     @Transactional(readOnly = true)
     public CalendarResponse getCalendar(Long workspaceId, LocalDateTime date) {
         validateLoginUserInWorkspace(workspaceId);
-
-        Long loginUserId = userUtil.getLoginUserId();
         Workspace workspace = findWorkspaceById(workspaceId);
 
         LocalDateTime startDate = getStartDate(date);
@@ -92,8 +91,6 @@ public class WorkspaceService {
     @Transactional(readOnly = true)
     public CalendarResponse getDailySchedules(Long workspaceId, LocalDateTime date) {
         validateLoginUserInWorkspace(workspaceId);
-
-        Long loginUserId = userUtil.getLoginUserId();
         Workspace workspace = findWorkspaceById(workspaceId);
 
         List<Schedule> schedules = scheduleRepository.searchByDate(

--- a/src/test/java/project/common/helper/ApiIntegrationTest.java
+++ b/src/test/java/project/common/helper/ApiIntegrationTest.java
@@ -1,5 +1,6 @@
 package project.common.helper;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.PostConstruct;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,7 +28,10 @@ public class ApiIntegrationTest {
     @Autowired
     protected MockMvc mvc;
 
-    protected String ACCESS_TOKEN;
+    @Autowired
+    protected ObjectMapper objectMapper;
+
+    protected String ACCESS_TOKEN_ADMIN;
     protected String ACCESS_TOKEN_USER;
     protected String ACCESS_TOKEN_OUTSIDER;
     protected String REFRESH_TOKEN;
@@ -37,7 +41,7 @@ public class ApiIntegrationTest {
     private void setAccessToken() {
         User user = userUtil.getUserById(1L);
 
-        ACCESS_TOKEN = "Bearer " + jwtProvider.createAccessTokenByUser(user);
+        ACCESS_TOKEN_ADMIN = "Bearer " + jwtProvider.createAccessTokenByUser(user);
         ACCESS_TOKEN_USER = "Bearer " + jwtProvider.createAccessTokenByUser(userUtil.getUserById(2L));
         ACCESS_TOKEN_OUTSIDER = "Bearer " + jwtProvider.createAccessTokenByUser(userUtil.getUserById(3L));
         ACCESS_TOKEN_NO_NICKNAME = "Bearer " + jwtProvider.createAccessTokenByUser(userUtil.getUserById(4L));

--- a/src/test/java/project/common/helper/ServiceIntegrationTest.java
+++ b/src/test/java/project/common/helper/ServiceIntegrationTest.java
@@ -4,13 +4,17 @@ import static project.common.constant.UserConstant.PASSWORD;
 
 import org.junit.jupiter.api.Tag;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
 import project.domain.user.dao.UserRepository;
 import project.domain.user.domain.User;
 import project.domain.workspace.dao.WorkspaceRepository;
 
 @Tag("integration")
+@ActiveProfiles("test")
 @SpringBootTest
+@Transactional // TODO: 직접 초기화 로직 작성하고 제거
 public class ServiceIntegrationTest {
 
     protected UserRepository userRepository;

--- a/src/test/java/project/domain/chat/api/ChatControllerTest.java
+++ b/src/test/java/project/domain/chat/api/ChatControllerTest.java
@@ -43,7 +43,7 @@ public class ChatControllerTest extends ApiIntegrationTest {
         String request = "{ \"content\" : \"hello\" }";
         // when
         mvc.perform(put("/v1/chats/1")
-                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_ADMIN)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(request))
                 // then
@@ -67,7 +67,7 @@ public class ChatControllerTest extends ApiIntegrationTest {
     public void 댓글_삭제() throws Exception {
         // given
         // when
-        mvc.perform(delete("/v1/chats/1").header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN))
+        mvc.perform(delete("/v1/chats/1").header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_ADMIN))
                 // then
                 .andExpect(status().isOk());
     }

--- a/src/test/java/project/domain/user/api/UserApiTest.java
+++ b/src/test/java/project/domain/user/api/UserApiTest.java
@@ -69,7 +69,7 @@ public class UserApiTest extends ApiIntegrationTest {
     public void 유저_정보_조회() throws Exception {
         // given
         // when
-        mvc.perform(get("/v1/users/me").header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN))
+        mvc.perform(get("/v1/users/me").header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_ADMIN))
                 // then
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.userId").value("1"))
@@ -88,7 +88,7 @@ public class UserApiTest extends ApiIntegrationTest {
 
         // when
         mvc.perform(put("/v1/users/me")
-                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_ADMIN)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(request))
                 // then
@@ -104,7 +104,7 @@ public class UserApiTest extends ApiIntegrationTest {
 
         // when
         mvc.perform(put("/v1/users/me")
-                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_ADMIN)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(request))
                 // then
@@ -120,7 +120,7 @@ public class UserApiTest extends ApiIntegrationTest {
 
         // when
         mvc.perform(put("/v1/users/me")
-                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_ADMIN)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(request))
                 // then
@@ -133,7 +133,7 @@ public class UserApiTest extends ApiIntegrationTest {
     public void 워크스페이스_조회() throws Exception {
         // given
         // when
-        mvc.perform(get("/v1/users/me/workspaces").header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN))
+        mvc.perform(get("/v1/users/me/workspaces").header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_ADMIN))
                 // then
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.userId").value("1"))
@@ -154,7 +154,7 @@ public class UserApiTest extends ApiIntegrationTest {
         // given
         String date = "202404";
         // when
-        mvc.perform(get("/v1/users/me/schedules?date=" + date).header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN))
+        mvc.perform(get("/v1/users/me/schedules?date=" + date).header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_ADMIN))
                 // then
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.userId").value("1"))
@@ -178,7 +178,7 @@ public class UserApiTest extends ApiIntegrationTest {
         // given
         String date = "202405";
         // when
-        mvc.perform(get("/v1/users/me/schedules?date=" + date).header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN))
+        mvc.perform(get("/v1/users/me/schedules?date=" + date).header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_ADMIN))
                 // then
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.userId").value("1"))
@@ -197,7 +197,7 @@ public class UserApiTest extends ApiIntegrationTest {
         // given
         String keyword = "test";
         // when
-        mvc.perform(get("/v1/users/search?keyword=" + keyword).header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN))
+        mvc.perform(get("/v1/users/search?keyword=" + keyword).header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_ADMIN))
                 // then
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.users[0].userId").value("2"))

--- a/src/test/java/project/domain/user/api/UserApiTest.java
+++ b/src/test/java/project/domain/user/api/UserApiTest.java
@@ -84,7 +84,7 @@ public class UserApiTest extends ApiIntegrationTest {
         // given
         String request = "{ \"nickName\" : \"test111\" ," + "\"currentPassword\" : \"test1234\" , "
                 + "\"newPassword\" : \"test4321\" , "
-                + "\"profile\" : \"https://d12v02yfguudwt.cloudfront.net/workspace.png\" }";
+                + "\"profile\" : \"https://d12v02yfguudwt.cloudfront.net/user.png\" }";
 
         // when
         mvc.perform(put("/v1/users/me")
@@ -100,7 +100,7 @@ public class UserApiTest extends ApiIntegrationTest {
         // given
         String request = " { \"currentPassword\" : \"test1234\" , "
                 + "\"newPassword\" : \"test4321\" , "
-                + "\"profile\" : \"https://d12v02yfguudwt.cloudfront.net/workspace.png\" }";
+                + "\"profile\" : \"https://d12v02yfguudwt.cloudfront.net/user.png\" }";
 
         // when
         mvc.perform(put("/v1/users/me")
@@ -116,7 +116,7 @@ public class UserApiTest extends ApiIntegrationTest {
         // given
         String request = " { \"currentPassword\" : \"test5555\" , "
                 + "\"newPassword\" : \"test4321\" , "
-                + "\"profile\" : \"https://d12v02yfguudwt.cloudfront.net/workspace.png\" }";
+                + "\"profile\" : \"https://d12v02yfguudwt.cloudfront.net/user.png\" }";
 
         // when
         mvc.perform(put("/v1/users/me")
@@ -137,16 +137,10 @@ public class UserApiTest extends ApiIntegrationTest {
                 // then
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.userId").value("1"))
-                .andExpect(jsonPath("$.workspaces[0].workspaceId").value("1"))
-                .andExpect(jsonPath("$.workspaces[0].workspaceName").value("testWorkspace1"))
-                .andExpect(jsonPath("$.workspaces[0].profile")
-                        .value("https://d12v02yfguudwt.cloudfront.net/workspace.png"))
-                .andExpect(jsonPath("$.workspaces[0].role").value("ADMIN"))
-                .andExpect(jsonPath("$.workspaces[1].workspaceId").value("2"))
-                .andExpect(jsonPath("$.workspaces[1].workspaceName").value("testWorkspace2"))
-                .andExpect(jsonPath("$.workspaces[1].profile")
-                        .value("https://d12v02yfguudwt.cloudfront.net/workspace.png"))
-                .andExpect(jsonPath("$.workspaces[1].role").value("ADMIN"));
+                .andExpect(jsonPath("$.workspaceUsers[0].workspaceId").value("1"))
+                .andExpect(jsonPath("$.workspaceUsers[0].role").value("ADMIN"))
+                .andExpect(jsonPath("$.workspaceUsers[1].workspaceId").value("2"))
+                .andExpect(jsonPath("$.workspaceUsers[1].role").value("ADMIN"));
     }
 
     @Test

--- a/src/test/java/project/domain/workspace/api/WorkspaceApiTest.java
+++ b/src/test/java/project/domain/workspace/api/WorkspaceApiTest.java
@@ -3,68 +3,45 @@ package project.domain.workspace.api;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static project.common.constant.ImageConstant.PROFILE_URL;
+import static project.common.constant.WorkspaceConstant.WORKSPACE_NAME;
 
 import org.junit.jupiter.api.*;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import project.common.helper.ApiIntegrationTest;
+import project.domain.workspace.dto.request.WorkspaceCreateRequest;
+import project.domain.workspace.dto.request.WorkspaceUpdateRequest;
 
-@Disabled("로직 변경에 따른 비활성화")
 public class WorkspaceApiTest extends ApiIntegrationTest {
 
     @Test
     public void 워크스페이스_생성() throws Exception {
         // given
-        String request = "{ \"name\" : \"testWorkspace3\" , \"users\" : [2, 3] }";
+        var request = new WorkspaceCreateRequest(WORKSPACE_NAME);
+        var json = objectMapper.writeValueAsString(request);
 
         // when
         mvc.perform(post("/v1/workspaces")
-                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_ADMIN)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(request))
+                        .content(json))
                 // then
-                .andExpect(status().isOk());
-    }
-
-    @Test
-    public void 워크스페이스_생성_잘못된_유저아이디() throws Exception {
-        // given
-        String request = "{ \"name\" : \"testWorkspace3\" , \"users\" : [2,3,99] }";
-
-        // when
-        mvc.perform(post("/v1/workspaces")
-                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(request))
-                // then
-                .andExpect(status().isNotFound());
-    }
-
-    @Test
-    public void 워크스페이스_생성_생성유저_포함() throws Exception {
-        // given
-        String request = "{ \"name\" : \"testWorkspace3\" , \"users\" : [1,2,3] }";
-
-        // when
-        mvc.perform(post("/v1/workspaces")
-                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(request))
-                // then
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$").isNumber());
     }
 
     @Test
     public void 워크스페이스_수정() throws Exception {
         // given
-        String request =
-                "{ \"name\" : \"testWorkspace11\" , \"profile\" : \"https://d12v02yfguudwt.cloudfront.net/user.png\" }";
+        var request = new WorkspaceUpdateRequest(WORKSPACE_NAME, PROFILE_URL);
+        var json = objectMapper.writeValueAsString(request);
 
         // when
         mvc.perform(put("/v1/workspaces/1")
-                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN)
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_ADMIN)
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(request))
+                        .content(json))
                 // then
                 .andExpect(status().isOk());
     }
@@ -72,14 +49,14 @@ public class WorkspaceApiTest extends ApiIntegrationTest {
     @Test // admin 권한이 없는 유저가 워크스페이스 수정 시도시 forbidden 에러 응답 반환
     public void 워크스페이스_수정_일반_유저_권한() throws Exception {
         // given
-        String request =
-                "{ \"name\" : \"testWorkspace11\" , \"profile\" : \"https://d12v02yfguudwt.cloudfront.net/user.png\" }";
+        var request = new WorkspaceUpdateRequest(WORKSPACE_NAME, PROFILE_URL);
+        var json = objectMapper.writeValueAsString(request);
 
         // when
         mvc.perform(put("/v1/workspaces/1")
-                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_USER)
+                        .header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_USER) // 일반 유저 토큰
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content(request))
+                        .content(json))
                 // then
                 .andExpect(status().isForbidden());
     }
@@ -88,12 +65,9 @@ public class WorkspaceApiTest extends ApiIntegrationTest {
     public void 워크스페이스_삭제() throws Exception {
         // given
         // when
-        mvc.perform(delete("/v1/workspaces/1").header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN))
+        mvc.perform(delete("/v1/workspaces/1").header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN_ADMIN))
                 // then
                 .andExpect(status().isOk());
-
-        mvc.perform(get("/v1/workspaces/1/users").header(HttpHeaders.AUTHORIZATION, ACCESS_TOKEN))
-                .andExpect(status().isNotFound());
     }
 
     @Test // admin 권한이 없는 유저가 워크스페이스 삭제 시도시 forbidden 에러 응답 반환
@@ -115,17 +89,10 @@ public class WorkspaceApiTest extends ApiIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.workspaceId").value("1"))
                 .andExpect(jsonPath("$.workspaceName").value("testWorkspace1"))
-                .andExpect(jsonPath("$.role").value("USER"))
                 .andExpect(jsonPath("$.schedules[0].scheduleId").value("1"))
-                .andExpect(jsonPath("$.schedules[0].scheduleName").value("testSchedule1"))
-                .andExpect(jsonPath("$.schedules[0].startDate").value("20240401"))
-                .andExpect(jsonPath("$.schedules[0].endDate").value("20240430"))
-                .andExpect(jsonPath("$.schedules[0].state").value("TODO"))
+                .andExpect(jsonPath("$.schedules[0].name").value("testSchedule1"))
                 .andExpect(jsonPath("$.schedules[1].scheduleId").value("2"))
-                .andExpect(jsonPath("$.schedules[1].scheduleName").value("testSchedule2"))
-                .andExpect(jsonPath("$.schedules[1].startDate").value("20240430"))
-                .andExpect(jsonPath("$.schedules[1].endDate").value("20240501"))
-                .andExpect(jsonPath("$.schedules[1].state").value("TODO"))
+                .andExpect(jsonPath("$.schedules[1].name").value("testSchedule2"))
                 .andExpect(jsonPath("$.schedules[2]").doesNotExist());
     }
 
@@ -150,12 +117,8 @@ public class WorkspaceApiTest extends ApiIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.workspaceId").value("1"))
                 .andExpect(jsonPath("$.workspaceName").value("testWorkspace1"))
-                .andExpect(jsonPath("$.role").value("USER"))
                 .andExpect(jsonPath("$.schedules[0].scheduleId").value("1"))
-                .andExpect(jsonPath("$.schedules[0].scheduleName").value("testSchedule1"))
-                .andExpect(jsonPath("$.schedules[0].startDate").value("20240401"))
-                .andExpect(jsonPath("$.schedules[0].endDate").value("20240430"))
-                .andExpect(jsonPath("$.schedules[0].state").value("TODO"))
+                .andExpect(jsonPath("$.schedules[0].name").value("testSchedule1"))
                 .andExpect(jsonPath("$.schedules[1]").doesNotExist());
     }
 
@@ -169,17 +132,10 @@ public class WorkspaceApiTest extends ApiIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.workspaceId").value("1"))
                 .andExpect(jsonPath("$.workspaceName").value("testWorkspace1"))
-                .andExpect(jsonPath("$.role").value("USER"))
                 .andExpect(jsonPath("$.schedules[0].scheduleId").value("1"))
-                .andExpect(jsonPath("$.schedules[0].scheduleName").value("testSchedule1"))
-                .andExpect(jsonPath("$.schedules[0].startDate").value("20240401"))
-                .andExpect(jsonPath("$.schedules[0].endDate").value("20240430"))
-                .andExpect(jsonPath("$.schedules[0].state").value("TODO"))
+                .andExpect(jsonPath("$.schedules[0].name").value("testSchedule1"))
                 .andExpect(jsonPath("$.schedules[1].scheduleId").value("2"))
-                .andExpect(jsonPath("$.schedules[1].scheduleName").value("testSchedule2"))
-                .andExpect(jsonPath("$.schedules[1].startDate").value("20240430"))
-                .andExpect(jsonPath("$.schedules[1].endDate").value("20240501"))
-                .andExpect(jsonPath("$.schedules[1].state").value("TODO"))
+                .andExpect(jsonPath("$.schedules[1].name").value("testSchedule2"))
                 .andExpect(jsonPath("$.schedules[2]").doesNotExist());
     }
 
@@ -193,12 +149,8 @@ public class WorkspaceApiTest extends ApiIntegrationTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.workspaceId").value("1"))
                 .andExpect(jsonPath("$.workspaceName").value("testWorkspace1"))
-                .andExpect(jsonPath("$.role").value("USER"))
                 .andExpect(jsonPath("$.schedules[0].scheduleId").value("1"))
-                .andExpect(jsonPath("$.schedules[0].scheduleName").value("testSchedule1"))
-                .andExpect(jsonPath("$.schedules[0].startDate").value("20240401"))
-                .andExpect(jsonPath("$.schedules[0].endDate").value("20240430"))
-                .andExpect(jsonPath("$.schedules[0].state").value("TODO"))
+                .andExpect(jsonPath("$.schedules[0].name").value("testSchedule1"))
                 .andExpect(jsonPath("$.schedules[1]").doesNotExist());
     }
 


### PR DESCRIPTION
## 관련 이슈
- close #88

## 변경사항
- Workspace 도메인에서 양방향 연관관계 완전 제거
- API 명세 변경에 따른 테스트 요청,응답 양식 변경
- 어드민 권한 검증 버그 수정
- h2 console 접근을 위한 시큐리티 설정 추가

## 참고사항
-

## 기타
-


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 로컬 환경에서 H2 콘솔 접근 허용 및 보안 규칙 분리 적용.
  - CORS 설정 확장으로 브라우저 호환성 개선.

- Refactor
  - API 보안 체계 재구성: 엔드포인트별 보안 체인 분리 및 관리 토큰 처리 개선(관리자 전용 흐름 포함).
  - 워크스페이스 생성 시 HTTP 201 Created 반환.
  - 사용자/워크스페이스 응답 스키마 변경: workspaceUsers 배열 도입 및 일정 필드명 name으로 통일.

- Bug Fixes
  - 관리자 권한 검증 로직 오류 수정.

- Chores
  - 더미 로그인 엔드포인트 제거.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->